### PR TITLE
Prefer deeper level of theorem numbering

### DIFF
--- a/src/base.typ
+++ b/src/base.typ
@@ -487,8 +487,8 @@
       let prev = query(selector(<_thm_marker>).before(here()))
       if prev.len() != 0 {
         let prev = prev.last()
-        let h = counter(heading).get().first()
-        if counter(heading).at(prev.location()).first() != h {
+        let h = counter(heading).get()
+        if counter(heading).at(prev.location()) != h {
           thm-counter.update(0)
         }
       }
@@ -512,8 +512,8 @@
       if heading.numbering == none {
         number = thmnr
       } else {
-        let h = counter(heading).get().first()
-        let h_fmt = numbering(heading.numbering, h)
+        let h = counter(heading).get()
+        let h_fmt = numbering(heading.numbering, ..h)
         if type(h_fmt) == str {
           h_fmt = h_fmt.trim(".", at: end)
         }


### PR DESCRIPTION
Hey,

I also preferred deeper level of theorem numbering noted in #9, so I made the following small (and still hardcoded) changes, solving it for my use case at least.
Sharing in a pull request in case you would also prefer that. Otherwise, for others to be able to make this change for themselves locally.
I believe this could also be made into a configuration flag somewhere, as to not change the previous default behavior, but I didn't look carefully to find where to put it or how to implement it.