### PR TITLE
feat(toc): allow auto for depth and nest theorems under current heading

### DIFF
--- a/src/base.typ
+++ b/src/base.typ
@@ -1149,7 +1149,7 @@
 /// -> content
 #let toc(
   /// Maximum depth of headings to conisder
-  /// -> int
+  /// -> int | auto
   depth: 2,
   /// list of @theorem.kind#[]s to ignore.
   /// #example(```typ
@@ -1193,7 +1193,7 @@
   /// -> bool
   sort: false,
 ) = context {
-  let level = if level == auto { depth + 1 } else { level }
+  let curr = 0
   let thms = query(selector(<_thm>).or(heading))
   if depth == 0 and sort {
     thms = array(thms)
@@ -1227,7 +1227,8 @@
     }
     if type(thm) != dictionary and thm.func() == heading {
       let level = thm.level
-      if level > depth or thm.outlined == false { continue }
+      if (depth != auto and level > depth) or thm.outlined == false  { continue }
+      curr = level
       let number = none
       if thm.numbering != none {
         number = numbering(thm.numbering, ..counter(heading).at(loc))
@@ -1236,7 +1237,9 @@
       // linebreak()
       toc-entry(level, loc, number, thm.body, p)
       // outline.entry(level, thm)
+
     } else {
+      let level = if level == auto {curr+1} else {level}
       let base = query(selector(metadata).after(loc, inclusive: false)).first().value
       if base == () or base.theorem-kind in exclude { continue }
       if type(thm.value.toctitle) == array {


### PR DESCRIPTION
Adds `auto` as a value for `depth`, which includes all outlined headings instead of requiring a fixed integer.

Theorem entries now nest under the heading they follow (`curr + 1`) when `level` is `auto`, where `curr` is the last displayed heading level. So they indent and de-indent as the document moves in and out of sections. Explicit integer `level` values are unchanged.

Heads up: this also changes the default rendering (`#toc()`), not just the new `auto` path — theorems now sit one level below the preceding heading rather than at a fixed depth.